### PR TITLE
How it does right before? WTF...

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,7 @@ services:
     hostname: mysql_master
     environment:
       - "MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}"
+      - "MYSQL_ROOT_HOST=%"
 #    ports:
 #      - "3306"
     volumes:
@@ -78,6 +79,7 @@ services:
     hostname: mysql_slave
     environment:
       - "MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}"
+      - "MYSQL_ROOT_HOST=%"
 #    ports:
 #      - "3306"
     depends_on:


### PR DESCRIPTION
Error Fix
Ubuntu 18.04 Error was:
ERROR 1130 (HY000): Host 'gentechops_mysql_configure_1.gentechops_backend' is not allowed to connect to this MySQL server

